### PR TITLE
Remove reliance on DB reports.proof_chain views

### DIFF
--- a/src/dbmanager.py
+++ b/src/dbmanager.py
@@ -14,12 +14,13 @@ class DBManager(threading.Thread):
     starting_point: int
     logger: logging.Logger
 
-    def __init__(self, user, password, database, host, starting_point):
+    def __init__(self, proofchain_address, schema, user, password, database, host, starting_point):
         super().__init__()
         self.host = host
         self.database = database
         self.password = password
         self.user = user
+        self.schema = schema
         self.last_block_id = None
 
         self.logger = logformat.get_logger("DB")
@@ -63,6 +64,81 @@ class DBManager(threading.Thread):
             password=self.password
         )
 
+    PROOF_CHAIN_VIEW_SQL = r"""
+    WITH
+    session_started_events AS (
+      SELECT session_started.tx_hash AS observer_chain_tx_hash,
+        session_started.block_id AS observer_chain_block_id,
+        session_started.tx_offset AS observer_chain_tx_offset,
+        session_started.topics[2]::numeric AS origin_chain_id,
+        session_started.topics[3]::numeric AS origin_chain_block_height,
+        abi_field(session_started.data, 0)::numeric AS proof_session_deadline
+      FROM {schema_name}.block_log_events session_started
+      JOIN {schema_name}.block_transactions trx
+        ON (trx.block_id = session_started.block_id AND trx.tx_offset = session_started.tx_offset)
+      WHERE
+        session_started.block_id > {last_block_id}
+        AND session_started.sender = '\x{contract_address}'::bytea
+        AND session_started.topics @> ARRAY[
+          '\x8b1f889addbfa41db5227bae3b091bd5c8b9a9122f874dfe54ba2f75aabe1f4c'::bytea
+        ]
+        AND trx.successful = TRUE
+      ORDER BY session_started.block_id ASC, session_started.log_offset ASC
+    ),
+    block_specimen_reward_awarded_events AS (
+      SELECT
+        fin.tx_hash AS observer_chain_tx_hash,
+        fin.topics[2]::numeric AS origin_chain_id,
+        fin.topics[3]::numeric AS origin_chain_block_height
+      FROM {schema_name}.block_log_events fin
+      JOIN {schema_name}.block_transactions trx_1
+        ON (trx_1.block_id = fin.block_id AND trx_1.tx_offset = fin.tx_offset)
+      WHERE
+        fin.block_id > {last_block_id}
+        AND fin.sender = '\x{contract_address}'::bytea
+        AND fin.topics @> ARRAY['\xf05ac779af1ec75a7b2fbe9415b33a67c00294a121786f7ce2eb3f92e4a6424a'::bytea]
+        AND trx_1.successful = TRUE
+      ORDER BY fin.block_id ASC, fin.log_offset ASC
+    ),
+    quorum_not_reached_events AS (
+      SELECT
+        fin.tx_hash AS observer_chain_tx_hash,
+        fin.topics[2]::numeric AS origin_chain_id,
+        public.abi_field(fin.data, 0)::numeric AS origin_chain_block_height
+      FROM {schema_name}.block_log_events fin
+      JOIN {schema_name}.block_transactions trx_1
+        ON (trx_1.block_id = fin.block_id AND trx_1.tx_offset = fin.tx_offset)
+      WHERE
+        fin.block_id > {last_block_id}
+        AND fin.sender = '\x{contract_address}'::bytea
+        AND fin.topics @> ARRAY['\x398fd8f638a7242217f011fd0720a06747f7a85b7d28d7276684b841baea4021'::bytea]
+        AND trx_1.successful = TRUE
+      ORDER BY fin.block_id ASC, fin.log_offset ASC
+    ),
+    all_finalization_events AS (
+      SELECT * FROM block_specimen_reward_awarded_events
+      UNION ALL
+      SELECT * FROM quorum_not_reached_events
+    )
+    SELECT
+      sse.observer_chain_tx_hash AS observer_chain_session_start_tx_hash,
+      sse.observer_chain_block_id AS observer_chain_session_start_block_id,
+      sse.observer_chain_tx_offset AS observer_chain_session_start_tx_offset,
+      sse.origin_chain_id,
+      sse.origin_chain_block_height,
+      sse.proof_session_deadline,
+      afe.observer_chain_tx_hash AS observer_chain_finalization_tx_hash
+    FROM session_started_events sse
+    LEFT JOIN all_finalization_events afe ON (
+      sse.origin_chain_id = afe.origin_chain_id
+      AND sse.origin_chain_block_height = afe.origin_chain_block_height
+    )
+    {finalization_filter_part}
+    ORDER BY sse.observer_chain_block_id ASC, sse.observer_chain_tx_offset ASC
+    ;
+
+    """
+
     def __main_loop(self):
         try:
             self.logger.info('Connecting to the database...')
@@ -71,11 +147,14 @@ class DBManager(threading.Thread):
 
                 with self.__connect() as conn:
                     with conn.cursor() as cur:
+                        sql = PROOF_CHAIN_VIEW_SQL.format(
+                            schema_name = self.schema,
+                            contract_address = self.proofchain_address,
+                            last_block_id = self.last_block_id,
+                            finalization_filter_part = r"WHERE afe.observer_chain_tx_hash IS NULL"
+                        )
                         # we are catching up. So we only need to grab what we need to attempt for finalizing
-                        cur.execute(
-                            r'SELECT * FROM reports.proof_chain_moonbeam WHERE observer_chain_session_start_block_id > %s AND observer_chain_finalization_tx_hash IS NULL;',
-                            (self.last_block_id,))
-
+                        cur.execute(sql)
                         outputs = cur.fetchall()
 
                 self.logger.info(f"Processing {len(outputs)} proof-session records...")
@@ -89,9 +168,12 @@ class DBManager(threading.Thread):
                     with conn.cursor() as cur:
                         self.logger.info(f"Incremental scan block_id={self.last_block_id}")
                         # we need everything after last max block number
-                        cur.execute(
-                            r'SELECT * FROM reports.proof_chain_moonbeam WHERE observer_chain_session_start_block_id > %s;',
-                            (self.last_block_id,))
+                        sql = PROOF_CHAIN_VIEW_SQL.format(
+                            schema_name = self.schema,
+                            contract_address = self.proofchain_address,
+                            last_block_id = self.last_block_id
+                        )
+                        cur.execute(sql)
                         outputs = cur.fetchall()
 
                 if self._process_outputs(outputs) == 0:

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
     DB_PASSWORD = os.getenv("DB_PASSWORD")
     DB_HOST = os.getenv("DB_HOST")
     DB_DATABASE = os.getenv("DB_DATABASE")
+    DB_SCHEMA = os.getenv("DB_SCHEMA")
 
     logging.basicConfig(
         stream=sys.stdout,
@@ -38,11 +39,13 @@ if __name__ == "__main__":
         finalizer_address=FINALIZER_ADDRESS
     )
     dbm = DBManager(
+        proofchain_address=PROOFCHAIN_ADDRESS,
         starting_point=int(BLOCK_ID_START),
         user=DB_USER,
         password=DB_PASSWORD,
         database=DB_DATABASE,
-        host=DB_HOST
+        host=DB_HOST,
+        schema=DB_SCHEMA
     )
     dbm.daemon = True
 


### PR DESCRIPTION
...and so support all chains by configuration — reuses existing env-var `PROOFCHAIN_ADDRESS`, but now requires new env-var `DB_SCHEMA`.

Also, this PR pushes timestamp-filtering down into pre-join part of query. (Postgres doesn't know how to do this by itself.) This optimizes proof-chain query runtime by 10x  — taking queries on e.g. `chain_moonbeam_mainnet` from ~40s to ~4s.