### PR TITLE
Skip retry for already known tx and cannot be finalized session

### DIFF
--- a/src/contract.py
+++ b/src/contract.py
@@ -158,6 +158,12 @@ class ProofChainContract:
 
                     # retry immediately (we already waited)
                     return (False, 0)
+                case (-32603, 'Session cannot be finalized'):
+                    self.logger.info("Skipping session that cannot be finalized...")
+                    return (True, None)
+                case (-32603, 'already known'):
+                    self.logger.info("Skipping finalization tx that's already known...")
+                    return (True, None)
                 case _:
                     raise
 


### PR DESCRIPTION
Signed-off-by: Pranay Valson <pranay.valson@gmail.com>

Issue faced on prod finalizer with failing txs in a loop that could not be finalized - since they were already finalized (but finalizer retried it anyway) and retries on already know transactions - that were already known but not mined yet (but finalized retried it anyway).

This adds the cases where those retries will be avoided.