### PR TITLE
change base docker image to python:3.10-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # set base image (host OS)
-FROM python:3.10-alpine
+FROM python:3.10-alpine3.17
 
 # set the working directory in the container
 WORKDIR /app
 
-RUN apk update && apk add --no-cache build-base postgresql-dev
+RUN apk update && apk add --no-cache build-base=0.5-r3 postgresql15-dev=15.2-r0
 
 # copy the dependencies file to the working directory
 COPY requirements.txt .


### PR DESCRIPTION
The base image has zero vulnerabilities detected, so should clear Vanta security scan this time. We are not likely going to use docker to run it though.