### PR TITLE
Moonbeam proof chain event view efficiency clauses

### DIFF
--- a/sql/proof_chain_moonbeam_view.sql
+++ b/sql/proof_chain_moonbeam_view.sql
@@ -16,6 +16,7 @@ session_started_events AS (
       '\x8b1f889addbfa41db5227bae3b091bd5c8b9a9122f874dfe54ba2f75aabe1f4c'::bytea
     ]
     AND trx.successful = TRUE
+    AND session_started.block_id >= '1928585162635558598'::bigint
   ORDER BY session_started.block_id ASC, session_started.log_offset ASC
 ),
 block_specimen_reward_awarded_events AS (
@@ -30,6 +31,7 @@ block_specimen_reward_awarded_events AS (
     fin.sender = '\x4f2e285227d43d9eb52799d0a28299540452446e'::bytea
     AND fin.topics @> ARRAY['\xf05ac779af1ec75a7b2fbe9415b33a67c00294a121786f7ce2eb3f92e4a6424a'::bytea]
     AND trx_1.successful = TRUE
+    AND fin.block_id >= '1928585162635558598'::bigint
   ORDER BY fin.block_id ASC, fin.log_offset ASC
 ),
 quorum_not_reached_events AS (
@@ -44,6 +46,7 @@ quorum_not_reached_events AS (
     fin.sender = '\x4f2e285227d43d9eb52799d0a28299540452446e'::bytea
     AND fin.topics @> ARRAY['\x398fd8f638a7242217f011fd0720a06747f7a85b7d28d7276684b841baea4021'::bytea]
     AND trx_1.successful = TRUE
+    AND fin.block_id >= '1928585162635558598'::bigint
   ORDER BY fin.block_id ASC, fin.log_offset ASC
 ),
 all_finalization_events AS (
@@ -64,5 +67,6 @@ LEFT JOIN all_finalization_events afe ON (
   sse.origin_chain_id = afe.origin_chain_id
   AND sse.origin_chain_block_height = afe.origin_chain_block_height
 )
+WHERE sse.origin_chain_block_height > 16925800::numeric
 ORDER BY sse.observer_chain_block_id ASC, sse.observer_chain_tx_offset ASC
 ;


### PR DESCRIPTION
In order to generate finalizer used views for moonbeam mainnet additional clauses have to be added to make the query efficient. 