### PR TITLE
Migrate `bsp-agent` build docker images from GCR to GAR

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -3,11 +3,11 @@ name: docker-ci
 on:
   push:
     branches:
-    - "main"
+      - "main"
   pull_request:
-    branches: 
-    - "main"
-    - "develop"
+    branches:
+      - "main"
+      - "develop"
 
 jobs:
   build:
@@ -16,12 +16,12 @@ jobs:
       - name: Login to GCR
         uses: docker/login-action@v2
         with:
-          registry: gcr.io
+          registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
 
       - uses: actions/checkout@v2
       - name: Build & Publish the Docker image
         run: |
-          docker build . --file Dockerfile --tag gcr.io/covalent-project/bsp-finalizer:latest
-          docker push gcr.io/covalent-project/bsp-finalizer:latest;
+          docker build . --file Dockerfile --tag us-docker.pkg.dev/covalent-project/network/bsp-finalizer:latest
+          docker push us-docker.pkg.dev/covalent-project/network/bsp-finalizer:latest;

--- a/README.md
+++ b/README.md
@@ -83,15 +83,15 @@ In order to run access to the covalent db is required. Please ask the code owner
 Pull the images and run (arm64) -
 
 ```bash
-    docker pull gcr.io/covalent-project/bsp-finalizer:latest
-    docker run --env-file .env gcr.io/covalent-project/bsp-finalizer:latest
+    docker pull us-docker.pkg.dev/covalent-project/network/bsp-finalizer:latest
+    docker run --env-file .env us-docker.pkg.dev/covalent-project/network/bsp-finalizer:latest
 ```
 
 1. Pull the images and run (amd64) -
 
 ```bash
-    docker pull gcr.io/covalent-project/bsp-finalizer:latest
-    docker run --env-file .env gcr.io/covalent-project/bsp-finalizer:latest
+    docker pull us-docker.pkg.dev/covalent-project/network/bsp-finalizer:latest
+    docker run --env-file .env us-docker.pkg.dev/covalent-project/network/bsp-finalizer:latest
 ```
 
 1. If the run is successful you should see logs such as below.


### PR DESCRIPTION
* GCR deprecated in favour of default GAR